### PR TITLE
Build qemu with --enable-pie

### DIFF
--- a/scripts/configure_qemu.sh
+++ b/scripts/configure_qemu.sh
@@ -41,6 +41,7 @@ set -x
   --prefix=/usr \
   --with-pkgversion=$QEMU_VERSION \
   --enable-linux-user \
+  --enable-pie \
   --disable-system \
   --static \
   --disable-brlapi \
@@ -59,7 +60,6 @@ set -x
   --disable-mpath \
   --disable-nettle \
   --disable-opengl \
-  --disable-pie \
   --disable-sdl \
   --disable-spice \
   --disable-tools \


### PR DESCRIPTION
It's likely to be the cause for crashes during aarch64 builds such as in
https://github.com/hassio-addons/addon-ubuntu-base/pull/150
```
69.17 Processing triggers for libc-bin (2.35-0ubuntu3.5) ...
69.38 Segmentation fault (core dumped)
69.52 Segmentation fault (core dumped)
69.52 dpkg: error processing package libc-bin (--configure):
69.52  installed libc-bin package post-installation script subprocess returned error exit status 139
85.86 Errors were encountered while processing:
85.86  libc-bin
85.94 E: Sub-process /usr/bin/dpkg returned an error code (1)
```

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1053101 and
https://gitlab.com/qemu-project/qemu/-/issues/1953 have more details